### PR TITLE
Changed PetriNet struct to Workflow_PetriNet

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ makedocs(
         "Introduction" => "index.md",
         "API" => "api.md",
         "Cluster" => "./Cluster/cluster.md",
-        "PetriNet" => "./PetriNet/PetriNet.md",
+        "Workflow" => "./PetriNet/PetriNet.md",
         "Scripting" => "./Scripting/scripting.md",
         "Serialization" => "./Serialization/custom_serializer.md"
     ]

--- a/examples/other_serializers/hdf5/workflow.jl
+++ b/examples/other_serializers/hdf5/workflow.jl
@@ -1,5 +1,5 @@
 # A Petri net with 2 input places and 2 output places
-pn = PetriNet("hello_julia_hdf5")
+pn = Workflow_PetriNet("hello_julia_hdf5")
 p1 = place("input_file1")
 p2 = place("input_file2")
 p3 = place("output_file1")

--- a/examples/other_serializers/jld2/workflow.jl
+++ b/examples/other_serializers/jld2/workflow.jl
@@ -1,5 +1,5 @@
 # A Petri net with 2 input places and 2 output places
-pn = PetriNet("hello_julia_jld2")
+pn = Workflow_PetriNet("hello_julia_jld2")
 p1 = place("input_file1")
 p2 = place("input_file2")
 p3 = place("output_file1")

--- a/examples/other_serializers/oscar_serializer/workflow.jl
+++ b/examples/other_serializers/oscar_serializer/workflow.jl
@@ -1,5 +1,5 @@
 # A Petri net with 2 input places and 2 output places
-pn = PetriNet("hello_julia_oscar")
+pn = Workflow_PetriNet("hello_julia_oscar")
 p1 = place("input_file1")
 p2 = place("input_file2")
 p3 = place("output_file1")

--- a/examples/petri_nets/hello_julia_net.jl
+++ b/examples/petri_nets/hello_julia_net.jl
@@ -1,5 +1,5 @@
 # A Petri net with 2 input places and 2 output places
-pn = PetriNet("hello_julia")
+pn = Workflow_PetriNet("hello_julia")
 p1 = place("input_file1")
 p2 = place("input_file2")
 p3 = place("output_file1")

--- a/examples/petri_nets/multi_module_net.jl
+++ b/examples/petri_nets/multi_module_net.jl
@@ -1,4 +1,4 @@
-pn = PetriNet("multi_module")
+pn = Workflow_PetriNet("multi_module")
 
 p1 = place("input_file")
 p2 = place("output_file0")

--- a/examples/petri_nets/parallel_reduce_net.jl
+++ b/examples/petri_nets/parallel_reduce_net.jl
@@ -1,4 +1,4 @@
-pn = PetriNet("parallel_reduce")
+pn = Workflow_PetriNet("parallel_reduce")
 
 p1 = place("input_file")
 p2 = place("partial_result")

--- a/examples/petri_nets/sequential_sum.jl
+++ b/examples/petri_nets/sequential_sum.jl
@@ -1,4 +1,4 @@
-pn = PetriNet("aggregate_sum")
+pn = Workflow_PetriNet("aggregate_sum")
 
 p1 = place("value")
 p2 = place("sum")

--- a/src/DistributedWorkflows.jl
+++ b/src/DistributedWorkflows.jl
@@ -7,11 +7,11 @@ module DistributedWorkflows
          compile_workflow, 
          connect,
          function_name, 
+         generate_workflow,
          implementation, 
          input_pair, 
          julia_implementation, 
          output_dir,
-         PetriNet, 
          place,
          port,
          port_info,
@@ -19,7 +19,7 @@ module DistributedWorkflows
          submit_workflow, 
          transition,
          workflow_config,
-         generate_workflow,
+         Workflow_PetriNet, 
          view_workflow
   
   include("init_calls.jl")

--- a/src/petri_net.jl
+++ b/src/petri_net.jl
@@ -24,7 +24,7 @@ julia> place("in_place", :control)
 Place "in_place" with control token created.
 ```
 
-See also [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
+See also [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
 """
 function place(name::String, token_type::Symbol=:string)
   possible_tokens = [:string, :control, :counter, :control_init]
@@ -76,7 +76,7 @@ A conditional transition "do_stuff" created.
 
 ```
 
-See also [`place`](@ref), [`arc`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`arc`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
 """
 function transition(name::String, condition::String="")
   Transition(name, condition, :mod, [])
@@ -104,7 +104,7 @@ A conditional transition "do_stuff" created.
 
 ```
 
-See also [`place`](@ref), [`arc`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`arc`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
 """
 function transition(name::String, type::Symbol, exp_str::Vector=[], condition::String="")
   if type != :exp
@@ -126,7 +126,7 @@ end
 # Transition "transition1" created.
 # ```
 
-# See also [`place`](@ref), [`arc`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`transition`](@ref).
+# See also [`place`](@ref), [`arc`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`transition`](@ref).
 # """
 # function parallel_reduce_transition(name::String, condition::String="")
 #   type = :reduce
@@ -142,7 +142,7 @@ end
 # Transition "transition1" created.
 # ```
 
-# See also [`place`](@ref), [`arc`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`reduce_transition`](@ref), [`transition`](@ref).
+# See also [`place`](@ref), [`arc`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`reduce_transition`](@ref), [`transition`](@ref).
 # """
 # function counter_transition(name::String, count::Symbol, n::Int, condition::String="")
 #   type = :counter
@@ -159,7 +159,7 @@ end
 # Transition "transition1" created.
 # ```
 
-# See also [`place`](@ref), [`arc`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`reduce_transition`](@ref), [`transition`](@ref).
+# See also [`place`](@ref), [`arc`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`reduce_transition`](@ref), [`transition`](@ref).
 # """
 # function weighted_transition(name::String, weight::Int, condition::String="")
 #   return Transition(name, condition, Symbol(weight))
@@ -176,7 +176,7 @@ julia> transition("transition1")
 Transition "transition1" created.
 ```
 
-See also [`place`](@ref), [`arc`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`transition`](@ref).
+See also [`place`](@ref), [`arc`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`transition`](@ref).
 """
 # function conditional_transition(name::String, condition::String="")
 # t1 = Transition(name, condition, :mod, [])
@@ -234,7 +234,7 @@ An arc of type "in", connecting the place: place1 to the transition: transition1
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
 """
 function arc(place::Place, transition::Transition, arc_type::Symbol)
   possible_arcs = [:in, :read, :inout, :out, :out_many]
@@ -274,7 +274,7 @@ A port of type "in" connected to place "input1".
 
 ```
 
-See also [`place`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref).
 """
 function port(type::Symbol, place::Place)
   possible_ports = [:in, :out, :inout]
@@ -296,7 +296,7 @@ end
 # Creating Petri nets
 # =============================================================================
 """
-    PetriNet(workflow_name::String)
+    Workflow_PetriNet(workflow_name::String)
 A struct creating an empty Petri net named: "workflow_name". Throws an error, if workflow name is not provided.
 
 Use the `connect()` function to populate the Petri net, and `remove()` function to remove Petri net components.
@@ -304,7 +304,7 @@ Use the `connect()` function to populate the Petri net, and `remove()` function 
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -351,13 +351,13 @@ A Petri net with name "hello_julia", having 3 ports, 3 places, and 1 transitions
 
 See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`connect`](@ref), [`remove`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
-struct PetriNet
+struct Workflow_PetriNet
   name::String
   places::Vector{Place}
   transitions::Vector{Transition}
   arcs::Vector{Arc}
   ports::Vector{Port}
-  function PetriNet(name::String)
+  function Workflow_PetriNet(name::String)
     if isempty(name)
       error("An empty string as Petri net name is not allowed. Please provide a name for the Petri net.")
     end
@@ -366,7 +366,7 @@ struct PetriNet
 end
 
 
-function Base.show(io::IO, Pnet::PetriNet)
+function Base.show(io::IO, Pnet::Workflow_PetriNet)
   k = length(Pnet.ports)
   n = length(Pnet.places)
   m = length(Pnet.transitions)
@@ -374,14 +374,14 @@ function Base.show(io::IO, Pnet::PetriNet)
 end
 
 """
-    connect(pnet::PetriNet, place::Place, transition::Transition, arc_type::Symbol)
-    connect(pnet::PetriNet, transition::Transition, place::Place, arc_type::Symbol)
+    connect(pnet::Workflow_PetriNet, place::Place, transition::Transition, arc_type::Symbol)
+    connect(pnet::Workflow_PetriNet, transition::Transition, place::Place, arc_type::Symbol)
 Given a Petri net connects the place to the transition with the given arc type. 
 
 # Examples
 ```julia-repl
 # initiating an empty Petri net.
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -426,9 +426,9 @@ A Petri net with name "hello_julia", having 3 ports, 3 places, and 1 transitions
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`remove`](@ref).
 """
-function connect(pnet::PetriNet, place::Place, transition::Transition, arc_type::Symbol)
+function connect(pnet::Workflow_PetriNet, place::Place, transition::Transition, arc_type::Symbol)
   connect_arc = arc(place, transition, arc_type)
   if !(connect_arc in pnet.arcs)
     push!(pnet.arcs, connect_arc)
@@ -443,17 +443,17 @@ function connect(pnet::PetriNet, place::Place, transition::Transition, arc_type:
   return pnet
 end
 
-connect(pnet::PetriNet, transition::Transition, place::Place, arc_type::Symbol) = connect(pnet, place, transition, arc_type)
+connect(pnet::Workflow_PetriNet, transition::Transition, place::Place, arc_type::Symbol) = connect(pnet, place, transition, arc_type)
 
 
 """
-    connect(pnet::PetriNet, places_arcs::Vector{Tuple{Place, Symbol}}, transition::Transition)
-    connect(pnet::PetriNet, transition::Transition, places_arcs::Vector{Tuple{Place, Symbol}})
+    connect(pnet::Workflow_PetriNet, places_arcs::Vector{Tuple{Place, Symbol}}, transition::Transition)
+    connect(pnet::Workflow_PetriNet, transition::Transition, places_arcs::Vector{Tuple{Place, Symbol}})
 Given a Petri net, connects the vector of tuples (places, arc_types) to the given transition. 
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -479,9 +479,9 @@ A Petri net with name "hello_julia", having 0 ports, 3 places, and 1 transitions
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`remove`](@ref).
 """
-function connect(pnet::PetriNet, places_arcs::Vector{Tuple{Place, Symbol}}, transition::Transition)
+function connect(pnet::Workflow_PetriNet, places_arcs::Vector{Tuple{Place, Symbol}}, transition::Transition)
   connect_list = Vector{Arc}()
   for (p, a) in places_arcs
     connect(pnet, p, transition, a)
@@ -489,17 +489,17 @@ function connect(pnet::PetriNet, places_arcs::Vector{Tuple{Place, Symbol}}, tran
   return pnet
 end
 
-connect(pnet::PetriNet, transition::Transition, places_arcs::Vector{Tuple{Place, Symbol}}) = connect(pnet, places_arcs, transition)
+connect(pnet::Workflow_PetriNet, transition::Transition, places_arcs::Vector{Tuple{Place, Symbol}}) = connect(pnet, places_arcs, transition)
 
 
 """
-    connect(pnet::PetriNet, place::Place, port::Port)
-    connect(pnet::PetriNet, port::Port, place::Place)
+    connect(pnet::Workflow_PetriNet, place::Place, port::Port)
+    connect(pnet::Workflow_PetriNet, port::Port, place::Place)
 Given a Petri net, connects the given place to the given port. 
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -536,9 +536,9 @@ A Petri net with name "hello_julia", having 3 ports, 3 places, and 1 transitions
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`remove`](@ref).
 """
-function connect(pnet::PetriNet, place::Place, port::Port)
+function connect(pnet::Workflow_PetriNet, place::Place, port::Port)
   if !(place in pnet.places)
     push!(pnet.places, place)
   end
@@ -548,16 +548,16 @@ function connect(pnet::PetriNet, place::Place, port::Port)
   return pnet
 end
 
-connect(pnet::PetriNet, port::Port, place::Place) = connect(pnet, place, port) 
+connect(pnet::Workflow_PetriNet, port::Port, place::Place) = connect(pnet, place, port) 
 
 """
-    connect(pnet::PetriNet, port_type::Symbol, place::Place)
-    connect(pnet::PetriNet, place::Place, port_type::Symbol)
+    connect(pnet::Workflow_PetriNet, port_type::Symbol, place::Place)
+    connect(pnet::Workflow_PetriNet, place::Place, port_type::Symbol)
 Given a Petri net, connects the given place to a port of name port_name and type port_type. 
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -590,30 +590,30 @@ A Petri net with name "hello_julia", having 1 ports, 3 places, and 1 transitions
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`remove`](@ref).
 """
-function connect(pnet::PetriNet, port_type::Symbol, place::Place)
+function connect(pnet::Workflow_PetriNet, port_type::Symbol, place::Place)
   pt = port(port_type, place)
   return connect(pnet, place, pt)
 end
 
-connect(pnet::PetriNet, place::Place, port_type::Symbol) = connect(pnet, port_type, place)
+connect(pnet::Workflow_PetriNet, place::Place, port_type::Symbol) = connect(pnet, port_type, place)
 
 """
-    connect(pnet::PetriNet, place_port::Vector{Tuple{Place, Symbol}})
-    connect(pnet::PetriNet, port_place::Vector{Tuple{Symbol, Place}})
+    connect(pnet::Workflow_PetriNet, place_port::Vector{Tuple{Place, Symbol}})
+    connect(pnet::Workflow_PetriNet, port_place::Vector{Tuple{Symbol, Place}})
 Given a Petri net, connects the given places to a port of name port_name and type port_type. 
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`remove`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`remove`](@ref).
 """
-function connect(pnet::PetriNet, place_port::Vector{Tuple{Place, Symbol}})
+function connect(pnet::Workflow_PetriNet, place_port::Vector{Tuple{Place, Symbol}})
   for (p, s) in place_port
     connect(pnet, p, s)
   end
   return pnet
 end
 
-function connect(pnet::PetriNet, port_place::Vector{Tuple{Symbol, Place}})
+function connect(pnet::Workflow_PetriNet, port_place::Vector{Tuple{Symbol, Place}})
   for (s, p) in place_port
     connect(pnet, p, s)
   end
@@ -622,12 +622,12 @@ end
 
 
 """
-    remove(pnet::PetriNet, place::Place)
+    remove(pnet::Workflow_PetriNet, place::Place)
 Remove the place from the given Petri net.  
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -685,9 +685,9 @@ julia> pn.places
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref).
 """
-function remove(pnet::PetriNet, place::Place)
+function remove(pnet::Workflow_PetriNet, place::Place)
   if place in pnet.places
     deleteat!(pnet.places, findall(x->x==place, pnet.places))
   end
@@ -715,12 +715,12 @@ function remove(pnet::PetriNet, place::Place)
 end
 
 """
-    remove(pnet::PetriNet,  transition::Transition)
+    remove(pnet::Workflow_PetriNet,  transition::Transition)
 Remove the transition from the given Petri net.  
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -771,9 +771,9 @@ DistributedWorkflows.Transition[]
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref).
 """
-function remove(pnet::PetriNet, transition::Transition)
+function remove(pnet::Workflow_PetriNet, transition::Transition)
   if transition in pnet.transitions
     deleteat!(pnet.transitions, findall(x->x==transition, pnet.transitions))
   end
@@ -791,12 +791,12 @@ function remove(pnet::PetriNet, transition::Transition)
 end
 
 """
-    remove(pnet::PetriNet, arc::Arc)
+    remove(pnet::Workflow_PetriNet, arc::Arc)
 Remove the arc from the given Petri net.  
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -858,9 +858,9 @@ julia> pn.arcs
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref).
 """
-function remove(pnet::PetriNet, arc::Arc)
+function remove(pnet::Workflow_PetriNet, arc::Arc)
   if arc in pnet.arcs
     deleteat!(pnet.arcs, findall(x->x==arc, pnet.arcs))
   end
@@ -868,12 +868,12 @@ function remove(pnet::PetriNet, arc::Arc)
 end
 
 """
-    remove(pnet::PetriNet, port::Port)
+    remove(pnet::Workflow_PetriNet, port::Port)
 Remove the port from the given Petri net.  
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -935,9 +935,9 @@ julia> pn.ports
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref).
 """
-function remove(pnet::PetriNet, port::Port)
+function remove(pnet::Workflow_PetriNet, port::Port)
   if port in pnet.ports
     deleteat!(pnet.ports, findall(x->x==port, pnet.ports))
   end

--- a/src/workflow_compiler.jl
+++ b/src/workflow_compiler.jl
@@ -15,7 +15,7 @@ Success: Workflow compiled
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`generate_workflow`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`generate_workflow`](@ref).
 """
 function compile_workflow(workflow::String, build_dir::String="")
   source_dir = joinpath(readchomp(`spack location -i gspcdriver`), "share/zeda-gspcdriver/utils")

--- a/src/workflow_renderer.jl
+++ b/src/workflow_renderer.jl
@@ -3,10 +3,10 @@
 # Petri net viewer using GraphViz
 # =============================================================================
 """
-    view_workflow(pnet::PetriNet)
-    view_workflow(pnet::PetriNet, format::Symbol)
-    view_workflow(pnet::PetriNet, path::String)
-    view_workflow(pnet::PetriNet, format::Symbol, path::String)
+    view_workflow(pnet::Workflow_PetriNet)
+    view_workflow(pnet::Workflow_PetriNet, format::Symbol)
+    view_workflow(pnet::Workflow_PetriNet, path::String)
+    view_workflow(pnet::Workflow_PetriNet, format::Symbol, path::String)
 By default this method generates a PNG file after compiling the Petri net into an XML workflow and compiling the workflow.
 If path is not given then the workflow image is stored in your home directory in the \"tmp/pnet\" folder.
 
@@ -19,7 +19,7 @@ https://graphviz.org/docs/outputs/
 # Examples
 ```julia-repl
 julia> # first generate a workflow in the form of a Petri net
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -76,10 +76,10 @@ julia> view_workflow(pn, "/home/pnet")
 
 ```
 
-See also [`PetriNet`](@ref), [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`compile_workflow`](@ref), [`generate_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`compile_workflow`](@ref), [`generate_workflow`](@ref).
 
 """
-function view_workflow(pnet::PetriNet, format::Symbol=:png, path::String="")
+function view_workflow(pnet::Workflow_PetriNet, format::Symbol=:png, path::String="")
   # collect ports based on their types in and out for shape
   in_ports = Vector{Port}()
   out_ports = Vector{Port}()
@@ -156,7 +156,7 @@ function view_workflow(pnet::PetriNet, format::Symbol=:png, path::String="")
   title = """label = "$(pnet.name)";"""
   pos = """labelloc = "t";"""
   gen_str_init = """
-  digraph petrinet {
+  digraph Workflow_PetriNet {
     $title
     $pos
 
@@ -288,6 +288,6 @@ end_gen = """
   return "An image of the workflow Petri net could be found in $(store_location)"
 end
 
-function view_workflow(pnet::PetriNet, path::String)
+function view_workflow(pnet::Workflow_PetriNet, path::String)
   return view_workflow(pnet, :png, path)
 end

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -19,7 +19,7 @@ Convenience constructor for configuring a workflow application with a single tra
 - `impl::String`: Julia file containing the implementation called by the workflow transition.
 - `fnames::String`: Function name to be executed by the workflow transition.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """ 
 application_config(port::String, impl::String, fname::String) = Application_config(port, impl, fname)
 
@@ -32,7 +32,7 @@ Constructor for configuring a workflow application with multiple transitions.
 - `impl::Vector{String}`: List of julia files containing the implementations called by the workflow transitions.
 - `fnames::Vector{String}`: List of function names to be executed by the workflow transitions.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 application_config(ports::Vector{String}, impl::Vector{String}, fnames::Vector{String}) = Application_config_many(ports, impl, fnames)
 
@@ -45,7 +45,7 @@ Convenience constructor for configuring a workflow application with multiple tra
 - `impl::String`: Julia file containing the implementations called by the workflow transitions.
 - `fnames::Vector{String}`: List of function names to be executed by the workflow transitions.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 application_config(ports::Vector{String}, impl::String, fnames::Vector{String}) = Application_config_many(ports, [impl], fnames)
 
@@ -61,7 +61,7 @@ The nodefile will be automatically populated with the local host name if it does
 - `log_host::String`: Host of the logging service.
 - `log_port::Int` : Port the logging service is listening on.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 function client(workers::Int, nodefile::String, rif_strategy::String, log_host::String, log_port::Int)
   if !isfile(nodefile) || rif_strategy=="local"
@@ -91,7 +91,7 @@ The nodefile will be automatically populated with the local host name if it does
 - `nodefile::String`: Location of the nodefile.
 - `rif_strategy::String`: Launch mode of the workflow infrastructure. Accepts `ssh` for distributing the workers across multiple nodes or `local` for running on the localhost only.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 function client(workers::Int, nodefile::String, rif_strategy::String)
   run(`touch $nodefile`)
@@ -118,7 +118,7 @@ Convenience key-value pair wrapper for function signature clarity and readabilit
 - `port_name::String`: Name of the port to contain the path string.
 - `path::String`: Path to an input data file.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref), [`port_info`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref), [`port_info`](@ref).
 """
 input_pair(port_name::String, path::String) = KeyValuePair(port_name, path)
 
@@ -130,7 +130,7 @@ Convenience key-value pair wrapper for function signature clarity and readabilit
 - `port_name::String`: Name of the port to contain the path string.
 - `path::String`: Path to a julia source file.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref), [`port_info`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref), [`port_info`](@ref).
 """
 implementation(port_name::String, path::String) = KeyValuePair(port_name, path)
 
@@ -155,7 +155,7 @@ Submit a configured workflow to a client instance.
 - `workflow`: A configured workflow object.
 - `input_params::Vector`: List of inputs for the workflow execution.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 function submit_workflow(client, workflow, input_params::Vector)
   input_vec = StdVector(input_params)
@@ -177,7 +177,7 @@ Configures a workflow for execution by a client instance.
 - `output_dir::String`: Location to store any output data generated during the workflow execution.
 - `app_config::Application_config`: Application configuration for the workflow exeuction.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 function workflow_config(workflow::String, output_dir::String, app_config::Application_config)
   run(`mkdir -p $output_dir`)
@@ -199,7 +199,7 @@ Configures a workflow for execution by a client instance.
 - `output_dir::String`: Location to store any output data generated during the workflow execution.
 - `app_config::Vector{Application_config}`: List of application configurations for the workflow exeuction.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 function workflow_config(workflow::String, output_dir::String, app_config::Vector{Application_config})
   run(`mkdir -p $output_dir`)
@@ -224,7 +224,7 @@ Configures a workflow for execution by a client instance.
 - `output_dir::String`: Location to store any output data generated during the workflow execution.
 - `app_config::Application_config_many`: Application configurations for the workflow exeuction.
 
-See also [`PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
+See also [`Workflow_PetriNet`](@ref), [`generate_workflow`](@ref), [`compile_workflow`](@ref).
 """
 function workflow_config(workflow::String, output_dir::String, app_config::Application_config_many)
   run(`mkdir -p $output_dir`)

--- a/src/xml_generator.jl
+++ b/src/xml_generator.jl
@@ -1,4 +1,4 @@
-function _xpnet_generator(pnet::PetriNet)
+function _xpnet_generator(pnet::Workflow_PetriNet)
   xpnet = XMLDocument()
   defun = create_root(xpnet, "defun")
   set_attribute(defun, "name", pnet.name)
@@ -181,13 +181,13 @@ end
 
 
 """
-    generate_workflow(pnet::PetriNet)
-    generate_workflow(pnet::PetriNet, path::String)
+    generate_workflow(pnet::Workflow_PetriNet)
+    generate_workflow(pnet::Workflow_PetriNet, path::String)
 Given a Petri net description, creates an XML workflow and writes it to a file in the path.
 
 # Examples
 ```julia-repl
-julia> pn = PetriNet("hello_julia")
+julia> pn = Workflow_PetriNet("hello_julia")
 A Petri net with name "hello_julia", having 0 ports, 0 places, and 0 transitions.
 
 
@@ -236,9 +236,9 @@ An XML workflow called: parallel_reduce.xpnet has been written to the location: 
 
 ```
 
-See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`compile_workflow`](@ref).
+See also [`place`](@ref), [`transition`](@ref), [`arc`](@ref), [`port`](@ref), [`Workflow_PetriNet`](@ref), [`connect`](@ref), [`remove`](@ref), [`compile_workflow`](@ref).
 """
-function generate_workflow(pnet::PetriNet, path::String="")
+function generate_workflow(pnet::Workflow_PetriNet, path::String="")
   xpnet = _xpnet_generator(pnet)
   dir = ""
   if !isempty(path)

--- a/test/workflow.jl
+++ b/test/workflow.jl
@@ -1,7 +1,7 @@
 @testset "Workflow related unit tests" begin
     # A Petri net with 2 input places and 2 output places
-    pn = PetriNet("test_net")
-    @test fieldcount(PetriNet) == 5
+    pn = Workflow_PetriNet("test_net")
+    @test fieldcount(Workflow_PetriNet) == 5
     p1 = place("input_file1")
     p2 = place("input_file2")
     p3 = place("output_file1")


### PR DESCRIPTION
Primarily to accommodate both experts and non-experts in terminology, the struct name is changed